### PR TITLE
Colorテーブルの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,16 @@ mysql> SELECT * FROM to_do;
 ```
 $ sbt run   // サーバーが起動したらlocalhost:9000にアクセス
 ```
+
+
+# ----- memo ------
+
+```sql
+mysql> CREATE TABLE `color` (
+        `id`         BIGINT(20)   UNSIGNED     NOT NULL AUTO_INCREMENT,
+        `colorcode`  MEDIUMINT UNSIGNED        NOT NULL,
+        `updated_at` TIMESTAMP                 NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        `created_at` TIMESTAMP                 NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (`id`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```

--- a/app/controllers/todo/CategoryController.scala
+++ b/app/controllers/todo/CategoryController.scala
@@ -9,7 +9,7 @@ import lib.persistence.onMySQL.driver
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import model.ViewValueHome
-import lib.persistence.CategoryRepository
+import lib.persistence.{CategoryRepository, ColorRepository}
 import model.todo.ViewValueCategoryList
 import lib.model.Category
 
@@ -24,11 +24,12 @@ class CategoryController @Inject()(val controllerComponents: ControllerComponent
   def listPage() = Action.async { implicit req =>
     for {
       value <- CategoryRepository().getAll
+      colorRef <- ColorRepository().createColorRef(value)
     } yield {
       val categoryListVV = ViewValueCategoryList(
         vv,
         CategoryRegisterFormData.form, SelectIdFormData.selectIdForm,
-        value.map(_.v))
+        value, colorRef)
       Ok(views.html.todo.CategoryList(categoryListVV))
     }
   }
@@ -43,11 +44,12 @@ class CategoryController @Inject()(val controllerComponents: ControllerComponent
       (formWithErrors: Form[CategoryRegisterFormData]) => {
         for {
           value <- CategoryRepository().getAll
+          colorRef <- ColorRepository().createColorRef(value)
         } yield { 
           val categoryListVV = ViewValueCategoryList(
             vv,
             formWithErrors, SelectIdFormData.selectIdForm,
-            value.map(_.v))
+            value, colorRef)
           BadRequest(views.html.todo.CategoryList(categoryListVV))
         }
       },

--- a/app/controllers/todo/CategoryController.scala
+++ b/app/controllers/todo/CategoryController.scala
@@ -9,7 +9,7 @@ import lib.persistence.onMySQL.driver
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import model.ViewValueHome
-import lib.persistence.{CategoryRepository, ColorRepository}
+import lib.persistence.CategoryRepository
 import model.todo.ViewValueCategoryList
 import lib.model.Category
 
@@ -24,7 +24,7 @@ class CategoryController @Inject()(val controllerComponents: ControllerComponent
   def listPage() = Action.async { implicit req =>
     for {
       value <- CategoryRepository().getAll
-      colorRef <- ColorRepository().createColorRef(value)
+      colorRef <- CategoryRepository().createColorRef(value)
     } yield {
       val categoryListVV = ViewValueCategoryList(
         vv,
@@ -44,7 +44,7 @@ class CategoryController @Inject()(val controllerComponents: ControllerComponent
       (formWithErrors: Form[CategoryRegisterFormData]) => {
         for {
           value <- CategoryRepository().getAll
-          colorRef <- ColorRepository().createColorRef(value)
+          colorRef <- CategoryRepository().createColorRef(value)
         } yield { 
           val categoryListVV = ViewValueCategoryList(
             vv,

--- a/app/controllers/todo/TodoController.scala
+++ b/app/controllers/todo/TodoController.scala
@@ -20,7 +20,7 @@ import play.api.data.Forms._
 import play.api.i18n._
 import ixias.model.Entity
 import lib.model.Category
-import lib.persistence.{CategoryRepository, ColorRepository}
+import lib.persistence.CategoryRepository
 
 @Singleton
 class TodoController @Inject()(val controllerComponents: ControllerComponents) extends BaseController with I18nSupport {
@@ -34,7 +34,7 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents) e
         for {
             todo <- TodoRepository().getAll
             category <- CategoryRepository().getAll
-            colorRef <- ColorRepository().createColorRef(category)
+            colorRef <- CategoryRepository().createColorRef(category)
         } yield {
             val todoListVV = ViewValueList(
                 vv,
@@ -52,7 +52,7 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents) e
         for {
             todo <- TodoRepository().getAll
             category <- CategoryRepository().getAll
-            colorRef <- ColorRepository().createColorRef(category)
+            colorRef <- CategoryRepository().createColorRef(category)
         } yield {
             val todoListVV = ViewValueList(
                 vv.copy(title = "ゴミ箱"),
@@ -72,7 +72,7 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents) e
                 for {
                     todo <- TodoRepository().getAll
                     category <- CategoryRepository().getAll
-                    colorRef <- ColorRepository().createColorRef(category)
+                    colorRef <- CategoryRepository().createColorRef(category)
                 } yield { 
                     val todoListVV = ViewValueList(
                         vv,

--- a/app/controllers/todo/TodoController.scala
+++ b/app/controllers/todo/TodoController.scala
@@ -20,7 +20,7 @@ import play.api.data.Forms._
 import play.api.i18n._
 import ixias.model.Entity
 import lib.model.Category
-import lib.persistence.CategoryRepository
+import lib.persistence.{CategoryRepository, ColorRepository}
 
 @Singleton
 class TodoController @Inject()(val controllerComponents: ControllerComponents) extends BaseController with I18nSupport {
@@ -34,11 +34,12 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents) e
         for {
             todo <- TodoRepository().getAll
             category <- CategoryRepository().getAll
+            colorRef <- ColorRepository().createColorRef(category)
         } yield {
             val todoListVV = ViewValueList(
                 vv,
                 RegisterFormData.registerForm, SelectIdFormData.selectIdForm,
-                todo.map(_.v), Todo.createCategoryRef(todo, category))
+                todo.map(_.v), Todo.createCategoryRef(todo, category), colorRef)
             Ok(views.html.todo.List(todoListVV))
         }
         // TodoRepository().getAll.map { value => 
@@ -51,11 +52,12 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents) e
         for {
             todo <- TodoRepository().getAll
             category <- CategoryRepository().getAll
+            colorRef <- ColorRepository().createColorRef(category)
         } yield {
             val todoListVV = ViewValueList(
                 vv.copy(title = "ゴミ箱"),
                 RegisterFormData.registerForm, SelectIdFormData.selectIdForm,
-                todo.map(_.v), Todo.createCategoryRef(todo, category))
+                todo.map(_.v), Todo.createCategoryRef(todo, category), colorRef)
             Ok(views.html.todo.Trush(todoListVV))
         }
         // TodoRepository().getAll.map { value => 
@@ -70,11 +72,12 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents) e
                 for {
                     todo <- TodoRepository().getAll
                     category <- CategoryRepository().getAll
+                    colorRef <- ColorRepository().createColorRef(category)
                 } yield { 
                     val todoListVV = ViewValueList(
                         vv,
                         formWithErrors, SelectIdFormData.selectIdForm,
-                        todo.map(_.v), Todo.createCategoryRef(todo, category))
+                        todo.map(_.v), Todo.createCategoryRef(todo, category), colorRef)
                     // Ok(views.html.todo.List(todoListVV))
                     BadRequest(views.html.todo.List(todoListVV))
                 }

--- a/app/lib/model/Color.scala
+++ b/app/lib/model/Color.scala
@@ -31,5 +31,8 @@ object Color {
     ))
   }
 
-  def convert(color: Color): String = s"#${color.colorcode.toHexString}"
+  def convert(color: Option[Color]): String = {
+    // none or 6桁の16進数に変換
+    color.fold("none")(value => s"#${"%06X".format(value.colorcode)}")
+  }
 }

--- a/app/lib/model/Color.scala
+++ b/app/lib/model/Color.scala
@@ -1,0 +1,35 @@
+package lib.model
+
+import ixias.model._
+import java.time.LocalDateTime
+
+import Color._
+
+      //    `id`         BIGINT(20)   UNSIGNED     NOT NULL AUTO_INCREMENT,
+      //    `colorcode`  MEDIUMINT UNSIGNED        NOT NULL,
+      //    `updated_at` TIMESTAMP                 NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      //    `created_at` TIMESTAMP                 NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      //    PRIMARY KEY (`id`)
+      //  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+case class Color(
+    id: Option[Id],
+    colorcode: Int,
+    updatedAt: LocalDateTime = NOW,
+    createdAt: LocalDateTime = NOW
+) extends EntityModel[Id]
+
+object Color {
+  val Id = the[Identity[Id]]
+  type Id = Long @@ Color
+  type WithNoId = Entity.WithNoId[Id, Color]
+  type EmbeddedId = Entity.EmbeddedId[Id, Color]
+
+  def apply(colorcode: Int): WithNoId = {
+    new Entity.WithNoId(new Color(
+      None, colorcode
+    ))
+  }
+
+  def convert(color: Color): String = s"#${color.colorcode.toHexString}"
+}

--- a/app/lib/model/Todo.scala
+++ b/app/lib/model/Todo.scala
@@ -36,16 +36,16 @@ object Todo {
     case object DONE        extends StateType(code = 2, state = 2)
   }
 
-  type CategoryRef = Map[Todo, Category]
+  type CategoryRef = Map[Todo, Category.EmbeddedId]
   def createCategoryRef(todo: Seq[Todo.EmbeddedId], categories: Seq[Category.EmbeddedId]): CategoryRef = {
     val categoryIdMap: Map[Category.Id, Category.EmbeddedId] = (for {
       category <- categories
     } yield (category.id -> category)).toMap
 
-    val categoryMap: Map[Todo, Category] = (for {
+    val categoryMap: Map[Todo, Category.EmbeddedId] = (for {
       value <- todo
       category <- categoryIdMap.get(value.v.categoryId)
-    } yield (value.v -> category.v)).toMap
+    } yield (value.v -> category)).toMap
 
     categoryMap
   }

--- a/app/lib/persistence/Category.scala
+++ b/app/lib/persistence/Category.scala
@@ -5,7 +5,6 @@ import ixias.persistence.SlickRepository
 import lib.model.Category
 import slick.jdbc.JdbcProfile
 import ixias.model.{Entity, IdStatus}
-import ixias.aws.qldb.dbio
 
 case class CategoryRepository[P <: JdbcProfile]()(implicit val driver: P)
   extends SlickRepository[Category.Id, Category, P]

--- a/app/lib/persistence/Category.scala
+++ b/app/lib/persistence/Category.scala
@@ -2,7 +2,7 @@ package lib.persistence
 
 import scala.concurrent.Future
 import ixias.persistence.SlickRepository
-import lib.model.Category
+import lib.model.{Category, Color}
 import slick.jdbc.JdbcProfile
 import ixias.model.{Entity, IdStatus}
 
@@ -20,6 +20,27 @@ case class CategoryRepository[P <: JdbcProfile]()(implicit val driver: P)
       RunDBAction(CategoryTable, "slave") {
         _.result
       }
+    
+    def createColorRef(categories: Seq[Category.EmbeddedId]): Future[ColorRepository.ColorRef] = {
+
+      val getColors: Future[Seq[Color.EmbeddedId]] = RunDBAction(ColorTable, "slave") {
+        _.filter(_.id.inSetBind(categories.map(category => Color.Id(category.v.color)))).result
+      }
+
+      for {
+        colors <- getColors
+
+        colorIdMap: Map[Color.Id, Color.EmbeddedId] = colors.map { color =>
+          color.id -> color
+        }.toMap
+
+        colorRef = categories.map { category =>
+          category -> colorIdMap.get(Color.Id(category.v.color))
+        }.toMap.collect {
+          case (key, Some(value)) => key -> value
+        }
+      } yield colorRef
+    }
 
     def add(entity: EntityWithNoId): Future[Id] =
       RunDBAction(CategoryTable) { slick =>

--- a/app/lib/persistence/Category.scala
+++ b/app/lib/persistence/Category.scala
@@ -2,7 +2,7 @@ package lib.persistence
 
 import scala.concurrent.Future
 import ixias.persistence.SlickRepository
-import lib.model.Category
+import lib.model.{Category, Color}
 import slick.jdbc.JdbcProfile
 import ixias.model.{Entity, IdStatus}
 
@@ -20,6 +20,27 @@ case class CategoryRepository[P <: JdbcProfile]()(implicit val driver: P)
       RunDBAction(CategoryTable, "slave") {
         _.result
       }
+    
+    def createColorRef(categories: Seq[Category.EmbeddedId]): Future[CategoryRepository.ColorRef] = {
+
+      val getColors: Future[Seq[Color.EmbeddedId]] = RunDBAction(ColorTable, "slave") {
+        _.filter(_.id.inSetBind(categories.map(category => Color.Id(category.v.color)))).result
+      }
+
+      for {
+        colors <- getColors
+
+        colorIdMap: Map[Color.Id, Color.EmbeddedId] = colors.map { color =>
+          color.id -> color
+        }.toMap
+
+        colorRef = categories.map { category =>
+          category -> colorIdMap.get(Color.Id(category.v.color))
+        }.toMap.collect {
+          case (key, Some(value)) => key -> value
+        }
+      } yield colorRef
+    }
 
     def add(entity: EntityWithNoId): Future[Id] =
       RunDBAction(CategoryTable) { slick =>
@@ -56,4 +77,8 @@ case class CategoryRepository[P <: JdbcProfile]()(implicit val driver: P)
         //     }
         //   } yield old
         // }
+}
+
+object CategoryRepository {
+  type ColorRef = Map[Category.EmbeddedId, Color.EmbeddedId]
 }

--- a/app/lib/persistence/Color.scala
+++ b/app/lib/persistence/Color.scala
@@ -17,27 +17,6 @@ case class ColorRepository[P <: JdbcProfile]()(implicit val driver: P)
         .filter(_.id === id)
         .result.headOption
       }
-    
-    def createColorRef(categories: Seq[Category.EmbeddedId]): Future[ColorRepository.ColorRef] = {
-
-      val getColors: Future[Seq[Color.EmbeddedId]] = RunDBAction(ColorTable, "slave") {
-        _.filter(_.id.inSetBind(categories.map(category => Color.Id(category.v.color)))).result
-      }
-
-      for {
-        colors <- getColors
-
-        colorIdMap: Map[Color.Id, Color.EmbeddedId] = colors.map { color =>
-          color.id -> color
-        }.toMap
-
-        colorRef = categories.map { category =>
-          category -> colorIdMap.get(Color.Id(category.v.color))
-        }.toMap.collect {
-          case (key, Some(value)) => key -> value
-        }
-      } yield colorRef
-    }
 
     def add(entity: EntityWithNoId): Future[Id] =
       RunDBAction(ColorTable) { slick =>

--- a/app/lib/persistence/Color.scala
+++ b/app/lib/persistence/Color.scala
@@ -1,0 +1,49 @@
+package lib.persistence
+
+import scala.concurrent.Future
+import ixias.persistence.SlickRepository
+import lib.model.Color
+import slick.jdbc.JdbcProfile
+import ixias.model.{Entity, IdStatus}
+import ixias.aws.qldb.dbio
+import lib.persistence.db.ColorTable
+
+case class ColorRepository[P <: JdbcProfile]()(implicit val driver: P)
+  extends SlickRepository[Color.Id, Color, P]
+  with db.SlickResourceProvider[P] {
+    import api._
+    def get(id: Id): Future[Option[EntityEmbeddedId]] =
+      RunDBAction(ColorTable, "slave") { _
+        .filter(_.id === id)
+        .result.headOption
+      }
+
+    def add(entity: EntityWithNoId): Future[Id] =
+      RunDBAction(ColorTable) { slick =>
+        slick returning slick.map(_.id) += entity.v
+      }
+    
+    def update(entity: EntityEmbeddedId): Future[Option[EntityEmbeddedId]] =
+        RunDBAction(ColorTable) { slick =>
+          val row = slick.filter(_.id === entity.id)
+          for {
+            old <- row.result.headOption
+            _ <- old match {
+              case None => DBIO.successful(0)
+              case Some(_) => row.update(entity.v)
+            }
+          } yield old
+        }
+    
+    def remove(id: Id): Future[Option[EntityEmbeddedId]] = ???
+        // RunDBAction(CategoryTable) { slick =>
+        //   val row = slick.filter(_.id === id)
+        //   for {
+        //     old <- row.result.headOption
+        //     _ <- old match {
+        //       case None => DBIO.successful(0)
+        //       case Some(_) => row.delete
+        //     }
+        //   } yield old
+        // }
+}

--- a/app/lib/persistence/Color.scala
+++ b/app/lib/persistence/Color.scala
@@ -17,27 +17,6 @@ case class ColorRepository[P <: JdbcProfile]()(implicit val driver: P)
         .filter(_.id === id)
         .result.headOption
       }
-    
-    def createColorRef(categories: Seq[Category.EmbeddedId]): Future[ColorRepository.ColorRef] = {
-
-      val getColors: Future[Seq[Color.EmbeddedId]] = RunDBAction(ColorTable, "slave") {
-        _.filter(_.id.inSetBind(categories.map(category => Color.Id(category.v.color)))).result
-      }
-
-      for {
-        colors <- getColors
-
-        colorIdMap: Map[Color.Id, Color.EmbeddedId] = colors.map { color =>
-          color.id -> color
-        }.toMap
-
-        colorRef = categories.map { category =>
-          category -> colorIdMap.get(Color.Id(category.v.color))
-        }.toMap.collect {
-          case (key, Some(value)) => key -> value
-        }
-      } yield colorRef
-    }
 
     def add(entity: EntityWithNoId): Future[Id] =
       RunDBAction(ColorTable) { slick =>
@@ -67,8 +46,4 @@ case class ColorRepository[P <: JdbcProfile]()(implicit val driver: P)
         //     }
         //   } yield old
         // }
-}
-
-object ColorRepository {
-  type ColorRef = Map[Category.EmbeddedId, Color.EmbeddedId]
 }

--- a/app/lib/persistence/db/Category.scala
+++ b/app/lib/persistence/db/Category.scala
@@ -36,17 +36,3 @@ case class CategoryTable[P <: JdbcProfile]()(implicit val driver: P) extends Tab
     )
   }
 }
-
-// TODO: 非常に良くないのでテーブルを作るかする
-object Color {
-  def convert(color: Int): String = {
-    color match {
-      // db number => css color
-      case 0 => "#888"
-      case 1 => "#ff0000"
-      case 2 => "#00ff00"
-      case 3 => "#0000ff"
-      case _ => "#aaa"
-    }
-  }
-}

--- a/app/lib/persistence/db/Color.scala
+++ b/app/lib/persistence/db/Color.scala
@@ -21,7 +21,7 @@ case class ColorTable[P <: JdbcProfile]()(implicit val driver: P) extends Table[
 
 
     def id = column[Id]("id", O.UInt64, O.PrimaryKey, O.AutoInc)
-    def colorcode = column[Int]("name", O.UInt32)
+    def colorcode = column[Int]("colorcode", O.UInt32)
     def updatedAt = column[LocalDateTime]("updated_at", O.TsCurrent)
     def createdAt = column[LocalDateTime]("created_at", O.Ts)
 

--- a/app/lib/persistence/db/Color.scala
+++ b/app/lib/persistence/db/Color.scala
@@ -1,0 +1,36 @@
+package lib.persistence.db
+
+import java.time.LocalDateTime
+import slick.jdbc.JdbcProfile
+import ixias.persistence.model.Table
+
+import lib.model.Color
+
+case class ColorTable[P <: JdbcProfile]()(implicit val driver: P) extends Table[Color, P] {
+  import api._
+  lazy val dsn = Map(
+    "master" -> DataSourceName("ixias.db.mysql://master/to_do"),
+    "slave" -> DataSourceName("ixias.db.mysql://slave/to_do")
+  )
+
+  class Query extends BasicQuery(new Table(_)) {}
+  lazy val query = new Query
+
+  class Table(tag: Tag) extends BasicTable(tag, "color") {
+    import Color._
+
+
+    def id = column[Id]("id", O.UInt64, O.PrimaryKey, O.AutoInc)
+    def colorcode = column[Int]("name", O.UInt32)
+    def updatedAt = column[LocalDateTime]("updated_at", O.TsCurrent)
+    def createdAt = column[LocalDateTime]("created_at", O.Ts)
+
+    type TableElementTuple = (Option[Id], Int, LocalDateTime, LocalDateTime)
+    def * = (id.?, colorcode, updatedAt, createdAt) <> (
+      (t: TableElementTuple) => Color.apply(t._1, t._2, t._3, t._4),
+      (v: TableElementType) => Color.unapply(v).map { t => (
+        t._1, t._2, LocalDateTime.now(), t._4
+      )}
+    )
+  }
+}

--- a/app/lib/persistence/db/SlickResourceProvider.scala
+++ b/app/lib/persistence/db/SlickResourceProvider.scala
@@ -15,8 +15,9 @@ trait SlickResourceProvider[P <: JdbcProfile] {
   object UserTable extends UserTable
   object TodoTable extends TodoTable
   object CategoryTable extends CategoryTable
+  object ColorTable extends ColorTable
   // --[ テーブル定義 ] --------------------------------------
   lazy val AllTables = Seq(
-    UserTable, TodoTable, CategoryTable
+    UserTable, TodoTable, CategoryTable, ColorTable
   )
 }

--- a/app/model/todo/ViewValueCategoryList.scala
+++ b/app/model/todo/ViewValueCategoryList.scala
@@ -12,7 +12,7 @@ case class ViewValueCategoryList(
   registerForm: Form[controllers.todo.CategoryRegisterFormData],
   selectIdForm: Form[controllers.todo.SelectIdFormData],
   categoryList: Seq[lib.model.Category.EmbeddedId],
-  colorRef: lib.persistence.ColorRepository.ColorRef
+  colorRef: lib.persistence.CategoryRepository.ColorRef
 ) extends HasCommon
 
 

--- a/app/model/todo/ViewValueCategoryList.scala
+++ b/app/model/todo/ViewValueCategoryList.scala
@@ -11,7 +11,8 @@ case class ViewValueCategoryList(
   common: ViewValueCommon,
   registerForm: Form[controllers.todo.CategoryRegisterFormData],
   selectIdForm: Form[controllers.todo.SelectIdFormData],
-  categoryList: Seq[lib.model.Category]
+  categoryList: Seq[lib.model.Category.EmbeddedId],
+  colorRef: lib.persistence.ColorRepository.ColorRef
 ) extends HasCommon
 
 

--- a/app/model/todo/ViewValueList.scala
+++ b/app/model/todo/ViewValueList.scala
@@ -14,7 +14,7 @@ case class ViewValueList(
   selectIdForm: Form[controllers.todo.SelectIdFormData],
   todoList: Seq[Todo],
   category: Todo.CategoryRef,
-  colorRef: lib.persistence.ColorRepository.ColorRef
+  colorRef: lib.persistence.CategoryRepository.ColorRef
 ) extends HasCommon
 
 

--- a/app/model/todo/ViewValueList.scala
+++ b/app/model/todo/ViewValueList.scala
@@ -13,7 +13,8 @@ case class ViewValueList(
   registerForm: Form[controllers.todo.RegisterFormData],
   selectIdForm: Form[controllers.todo.SelectIdFormData],
   todoList: Seq[Todo],
-  category: Todo.CategoryRef
+  category: Todo.CategoryRef,
+  colorRef: lib.persistence.ColorRepository.ColorRef
 ) extends HasCommon
 
 

--- a/app/views/todo/CategoryList.scala.html
+++ b/app/views/todo/CategoryList.scala.html
@@ -19,10 +19,10 @@
   <ul class="category-list">
     @for(category <- vv.categoryList) {
       <input class="category-list__checkbox" type="checkbox" id="select_id_@category.id" name="ids[]" value=@category.id>
-      <label for="select_id_@category.id" class="category-list__label" style="background-color: @lib.persistence.db.Color.convert(category.color)">
+      <label for="select_id_@category.id" class="category-list__label" style="background-color: @lib.model.Color.convert(vv.colorRef.get(category).map(_.v))">
         <li class="category-list__item">
-          <h2 class="category-list__title">@category.name</h2>
-          <p class="category-list__name">@category.slug</p>
+          <h2 class="category-list__title">@category.v.name</h2>
+          <p class="category-list__name">@category.v.slug</p>
         </li>
       </label>
     }

--- a/app/views/todo/List.scala.html
+++ b/app/views/todo/List.scala.html
@@ -2,7 +2,7 @@
 @common.Default(vv){
     <a href="@controllers.todo.routes.TodoController.trushPage()">ゴミ箱へ</a>
 
-    @UpdateForm(vv.registerForm, vv.category.values.toSeq)
+    @UpdateForm(vv.registerForm, vv.category.values.toSeq.map(_.v))
 
     @helper.form(action = controllers.todo.routes.TodoController.update()) {
         @helper.CSRF.formField
@@ -18,8 +18,7 @@
                             </p>
                             @vv.category.get(todo) match {
                                 case Some(category) => {
-                                    @lib.persistence.db.Color.convert(category.color)
-                                    <span class="todo-list__category" style="background-color: red">#@category.name</span>
+                                    <span class="todo-list__category" style="background-color: @lib.model.Color.convert(vv.colorRef.get(category).map(_.v))">#@category.v.name</span>
                                 }
                                 case None => {
                                     <span class="todo-list__category">no category</span>


### PR DESCRIPTION
* カテゴリーに関する色の決定を行うテーブルを追加
* カテゴリーを表示する際に、Colorテーブルを参照するように変更


Todo-Category間の参照と、Category-Color間の参照の実装方法が違うため追加でリファクタリングを行う。
Colorに関する管理方法が無いため実装する。